### PR TITLE
feat: add docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.24-alpine AS builder
+
+ENV GOTOOLCHAIN=auto
+
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN go build -o bot .
+RUN go build -o migrate ./cmd/migrate
+
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates tzdata
+COPY --from=builder /app/bot /bot
+COPY --from=builder /app/migrate /migrate
+COPY --from=builder /app/database/migrations /database/migrations
+
+ENTRYPOINT ["/bot"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  bot:
+    build: .
+    container_name: markovbot
+    restart: unless-stopped
+    volumes:
+      - ./settings.json:/settings.json:ro
+    networks:
+      - backend
+
+  migrate:
+    build: .
+    entrypoint: ["/migrate"]
+    volumes:
+      - ./settings.json:/settings.json:ro
+    networks:
+      - backend
+
+networks:
+  backend:
+    external: true


### PR DESCRIPTION
Adds a Dockerfile and docker-compose.yml to run the bot on a homeserver. The image is built in two stages, with both the bot and migrate binaries included. settings.json is bind-mounted so secrets stay out of the image.

Run migrations with `docker compose run --rm migrate`, then `docker compose up -d bot`.