### PR TITLE
fix: replace per channel stream pollers with a single shared poller

### DIFF
--- a/chatbot/bot.go
+++ b/chatbot/bot.go
@@ -65,9 +65,6 @@ func New(ctx context.Context, cfg settings.BotConfig, db *database.Database, liv
 
 	for name, ch := range bot.channels {
 		client.Join(name)
-		if live != nil {
-			go ch.startPoller(ctx, live)
-		}
 		if !ch.cfg.TrainingMode && ch.cfg.AutoGenerateMessages {
 			go ch.startAutoGenerate(ctx)
 		}

--- a/chatbot/channel.go
+++ b/chatbot/channel.go
@@ -17,8 +17,6 @@ import (
 	twitch "github.com/gempir/go-twitch-irc/v4"
 )
 
-const streamPollInterval = 60 * time.Second
-
 type channel struct {
 	id     int
 	markov *markov.Generator
@@ -35,37 +33,6 @@ func newChannel(cfg settings.ChannelConfig, channelID int, client *twitch.Client
 		cfg:    cfg,
 		client: client,
 		db:     db,
-	}
-}
-
-func (c *channel) startPoller(ctx context.Context, live LiveChecker) {
-	check := func() {
-		statuses, err := live([]string{c.cfg.ChannelName})
-		if err != nil {
-			slog.Warn("stream status check failed", "channel", c.cfg.ChannelName, "error", err)
-			return
-		}
-		nowLive := statuses[c.cfg.ChannelName]
-		if wasLive := c.isLive.Swap(nowLive); nowLive != wasLive {
-			if nowLive {
-				slog.Info("stream live", "channel", c.cfg.ChannelName)
-			} else {
-				slog.Info("stream offline", "channel", c.cfg.ChannelName)
-			}
-		}
-	}
-
-	check()
-
-	ticker := time.NewTicker(streamPollInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			check()
-		}
 	}
 }
 

--- a/chatbot/poller.go
+++ b/chatbot/poller.go
@@ -1,0 +1,67 @@
+package chatbot
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+const streamPollInterval = 60 * time.Second
+
+// StartLivePoller periodically checks the live status of every channel across
+// the given bots with a single LiveChecker call per tick and updates each
+// channel's live flag. It blocks until ctx is cancelled.
+func StartLivePoller(ctx context.Context, live LiveChecker, bots []*Bot) {
+	type target struct {
+		login string
+		ch    *channel
+	}
+	var targets []target
+	var logins []string
+	seen := make(map[string]bool)
+	for _, bot := range bots {
+		for name, ch := range bot.channels {
+			login := strings.ToLower(name)
+			targets = append(targets, target{login, ch})
+			if !seen[login] {
+				seen[login] = true
+				logins = append(logins, login)
+			}
+		}
+	}
+	if len(targets) == 0 {
+		return
+	}
+
+	check := func() {
+		statuses, err := live(logins)
+		if err != nil {
+			slog.Warn("stream status check failed", "error", err)
+			return
+		}
+		for _, t := range targets {
+			nowLive := statuses[t.login]
+			if wasLive := t.ch.isLive.Swap(nowLive); nowLive != wasLive {
+				if nowLive {
+					slog.Info("stream live", "channel", t.login)
+				} else {
+					slog.Info("stream offline", "channel", t.login)
+				}
+			}
+		}
+	}
+
+	check()
+
+	ticker := time.NewTicker(streamPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			check()
+		}
+	}
+}

--- a/helix/helix.go
+++ b/helix/helix.go
@@ -2,19 +2,16 @@ package helix
 
 import (
 	"fmt"
-	"sync"
-	"time"
+	"strings"
 
 	helixlib "github.com/nicklaw5/helix/v2"
 )
 
-const cacheTTL = 60 * time.Second
+// Helix allows at most 100 user logins per Get Streams request.
+const maxLoginsPerRequest = 100
 
 type Client struct {
-	api      *helixlib.Client
-	mu       sync.Mutex
-	cachedAt time.Time
-	cached   map[string]bool
+	api *helixlib.Client
 }
 
 func New(clientID, clientSecret string) (*Client, error) {
@@ -35,37 +32,37 @@ func New(clientID, clientSecret string) (*Client, error) {
 	return &Client{api: api}, nil
 }
 
-// LiveChannels returns a map of channel name to live status.
-// Results are cached for 60 seconds; repeated calls within that window
-// return the cached value without hitting the API.
+// LiveChannels returns a map of lowercase channel login to live status.
+// Every requested channel is present in the result; channels not currently
+// streaming map to false.
 func (c *Client) LiveChannels(channels []string) (map[string]bool, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.cached != nil && time.Since(c.cachedAt) < cacheTTL {
-		return c.cached, nil
-	}
-
 	result := make(map[string]bool, len(channels))
+	logins := make([]string, 0, len(channels))
 	for _, ch := range channels {
-		result[ch] = false
+		login := strings.ToLower(ch)
+		if _, ok := result[login]; !ok {
+			result[login] = false
+			logins = append(logins, login)
+		}
 	}
 
-	resp, err := c.api.GetStreams(&helixlib.StreamsParams{
-		UserLogins: channels,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("get streams: %w", err)
-	}
-	if resp.ErrorMessage != "" {
-		return nil, fmt.Errorf("helix: %s", resp.ErrorMessage)
+	for start := 0; start < len(logins); start += maxLoginsPerRequest {
+		batch := logins[start:min(start+maxLoginsPerRequest, len(logins))]
+		resp, err := c.api.GetStreams(&helixlib.StreamsParams{
+			UserLogins: batch,
+			First:      len(batch),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("get streams: %w", err)
+		}
+		if resp.ErrorMessage != "" {
+			return nil, fmt.Errorf("helix: %s", resp.ErrorMessage)
+		}
+
+		for _, stream := range resp.Data.Streams {
+			result[strings.ToLower(stream.UserLogin)] = true
+		}
 	}
 
-	for _, stream := range resp.Data.Streams {
-		result[stream.UserLogin] = true
-	}
-
-	c.cached = result
-	c.cachedAt = time.Now()
 	return result, nil
 }

--- a/main.go
+++ b/main.go
@@ -56,11 +56,18 @@ func main() {
 		slog.Warn("helix credentials not set, all channels treated as always live")
 	}
 
+	bots := make([]*chatbot.Bot, 0, len(cfg.Bots))
 	for _, botCfg := range cfg.Bots {
-		if _, err := chatbot.New(ctx, botCfg, db, live); err != nil {
+		bot, err := chatbot.New(ctx, botCfg, db, live)
+		if err != nil {
 			slog.Error("failed to start bot", "bot", botCfg.BotUsername, "error", err)
 			os.Exit(1)
 		}
+		bots = append(bots, bot)
+	}
+
+	if live != nil {
+		go chatbot.StartLivePoller(ctx, live, bots)
 	}
 
 	<-ctx.Done()


### PR DESCRIPTION
Live status was flapping even when the streamer was consistently live. Each channel ran its own poller that queried only its own login, but the helix client cached one global result map for whatever channel refreshed it last, so other channels read a map they were not in and defaulted to online. Whichever poller won the refresh race each minute decided everyone's status.

Channels are now polled by a single shared poller that checks every channel across all bots with one batched get streams call per tick. The helix cache is removed since there is only one caller.