### PR TITLE
ci: add build, test, and docker publish workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Check formatting
+        run: test -z "$(gofmt -l .)"
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./...
+
+  docker:
+    needs: test
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag
+            type=sha
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -22,14 +26,11 @@ jobs:
       - name: Check formatting
         run: test -z "$(gofmt -l .)"
 
-      - name: Vet
-        run: go vet ./...
-
       - name: Build
         run: go build ./...
 
       - name: Test
-        run: go test -coverprofile=cover.out ./...
+        run: go test -race -coverprofile=cover.out ./...
 
       - name: Convert coverage to Cobertura
         run: go run github.com/boumenot/gocover-cobertura@latest < cover.out > coverage.xml
@@ -46,8 +47,26 @@ jobs:
       - name: Publish coverage summary
         run: cat code-coverage-results.md >> "$GITHUB_STEP_SUMMARY"
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - uses: golangci/golangci-lint-action@v8
+
+  vulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: golang/govulncheck-action@v1
+        with:
+          go-version-file: go.mod
+
   docker:
-    needs: test
+    needs: [test, lint]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,22 @@ jobs:
         run: go build ./...
 
       - name: Test
-        run: go test ./...
+        run: go test -coverprofile=cover.out ./...
+
+      - name: Convert coverage to Cobertura
+        run: go run github.com/boumenot/gocover-cobertura@latest < cover.out > coverage.xml
+
+      - name: Render coverage report
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: coverage.xml
+          format: markdown
+          badge: true
+          hide_branch_rate: true
+          output: file
+
+      - name: Publish coverage summary
+        run: cat code-coverage-results.md >> "$GITHUB_STEP_SUMMARY"
 
   docker:
     needs: test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+version: "2"
+
+linters:
+  settings:
+    errcheck:
+      exclude-functions:
+        - (*database/sql.DB).Close
+        - (*database/sql.Rows).Close

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,48 @@
 version: "2"
 
 linters:
+  enable:
+    # bugs
+    - bodyclose
+    - copyloopvar
+    - durationcheck
+    - errorlint
+    - gocritic
+    - intrange
+    - nilerr
+    - nolintlint
+    - rowserrcheck
+    - sqlclosecheck
+    - unconvert
+    - unparam
+    - wastedassign
+    # style
+    - goconst
+    - gocyclo
+    - godot
+    - misspell
+    - nakedret
+    - predeclared
+    - revive
+    - thelper
+    - usestdlibvars
+    - whitespace
   settings:
     errcheck:
       exclude-functions:
         - (*database/sql.DB).Close
         - (*database/sql.Rows).Close
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - goconst
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - markovchain-chatbot

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Markov Chain Chatbot
 
+[![CI](https://github.com/Karolinskis/MarkovChain-Chatbot/actions/workflows/ci.yml/badge.svg)](https://github.com/Karolinskis/MarkovChain-Chatbot/actions/workflows/ci.yml)
+
 A Twitch chatbot that learns from chat in realtime and generates messages using a second-order Markov chain. Inspired by [TwitchMarkovChain](https://github.com/tomaarsen/TwitchMarkovChain).
 
 ## Features


### PR DESCRIPTION
Adds a GitHub Actions pipeline:

- **test**: gofmt check, go vet, build, and unit tests on every PR and push to main
- **docker**: on main pushes and v* tags (after tests pass), builds the image and publishes it to `ghcr.io/karolinskis/markovchain-chatbot` with `latest`/version/SHA tags

Also adds a CI badge to the README.